### PR TITLE
Implement querying API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BIN-LIB       = $(BIN-SRC:src/bin/%=bin/%)
 SRC           = $(filter-out $(TESTS), $(shell find src -name '*' -type f))
 LIB           = $(SRC:src/%=lib/%)
 NODE          = $(BIN)/babel-node $(BABEL_OPTIONS)
-MOCHA_OPTIONS = --compilers js:babel/register --require ./src/__tests__/setup.js
+MOCHA_OPTIONS = --compilers js:babel/register
 MOCHA					= NODE_ENV=test iojs $(BIN)/mocha $(MOCHA_OPTIONS)
 
 build:

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "history": "^1.9.1",
     "invariant": "^2.1.0",
     "json-loader": "^0.5.3",
+    "minimatch": "^2.0.10",
     "react-transform-hmr": "^1.0.0",
     "rimraf": "^2.4.3",
     "sitegen-loader-markdown": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,11 @@
   "devDependencies": {
     "babel": "^5.8.23",
     "babel-eslint": "^4.1.2",
+    "babel-plugin-espower": "^1.0.0",
     "eslint": "^1.4.3",
     "eslint-plugin-react": "^3.3.2",
+    "mocha": "^2.3.3",
+    "power-assert": "^1.0.1",
     "react": "^0.14.0-rc1",
     "react-dom": "^0.14.0-rc1",
     "react-router": "^1.0.0-rc1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "sitegen-build": "./bin/sitegen-build"
   },
   "scripts": {
-    "test": "make lint"
+    "test": "make test lint"
   },
   "repository": {
     "type": "git",

--- a/src/QueryAPIBabelPlugin.js
+++ b/src/QueryAPIBabelPlugin.js
@@ -93,7 +93,8 @@ function parseRequest(request) {
     directory = directory.join('/');
   }
   pattern = new minimatch.Minimatch(request.substring(directory.length + 1));
-  return {directory, regexp: pattern.makeRe()};
+  let regexp = pattern.makeRe() || /.+/;
+  return {directory, regexp};
 }
 
 function isSitegenAPI(name, node) {

--- a/src/QueryAPIBabelPlugin.js
+++ b/src/QueryAPIBabelPlugin.js
@@ -143,7 +143,7 @@ function makeSitegenAPIRecognizer(file) {
       }
     }
     return true;
-  }
+  };
 }
 
 function parseRequest(request) {

--- a/src/QueryAPIBabelPlugin.js
+++ b/src/QueryAPIBabelPlugin.js
@@ -1,7 +1,10 @@
-import invariant from 'invariant';
 import minimatch from 'minimatch';
 
 export default function QueryAPIBabelPlugin({Plugin, types: t}) {
+
+  let requireSitegenAPIImpl = t.callExpression(
+    t.identifier('require'),
+    [t.literal('sitegen/internal')]);
 
   function makeRegExpLiteral(re) {
     return {
@@ -12,10 +15,8 @@ export default function QueryAPIBabelPlugin({Plugin, types: t}) {
 
   function makeSitegenAPICall(name, args) {
     let callee = t.memberExpression(
-      t.identifier('Sitegen'),
-      t.identifier('__internal')
-    );
-    callee = t.memberExpression(callee, t.identifier(name));
+      requireSitegenAPIImpl,
+      t.identifier(name));
     return t.callExpression(callee, args);
   }
 
@@ -36,42 +37,47 @@ export default function QueryAPIBabelPlugin({Plugin, types: t}) {
 
   return new Plugin('sitegen-query-api', {
     visitor: {
-      CallExpression(node) {
 
-        if (isSitegenAPI('includePage', node)) {
-          checkSitegenAPI('includePage', node);
+      CallExpression(node, parent, scope, file) {
+
+        if (!file.isSitegenAPI) {
+          file.isSitegenAPI = makeSitegenAPIRecognizer(file);
+        }
+
+        if (file.isSitegenAPI('includePage', node, scope)) {
+          checkSitegenAPI('includePage', node, file);
           let request = node.arguments[0].value;
           let moduleNode = makeRequire(`page!${request}`);
           return makeSitegenAPICall('wrapPageModule', [moduleNode]);
 
-        } else if (isSitegenAPI('includePages', node)) {
-          checkSitegenAPI('includePages', node);
+        } else if (file.isSitegenAPI('includePages', node, scope)) {
+          checkSitegenAPI('includePages', node, file);
           let request = node.arguments[0].value;
           let {directory, regexp} = parseRequest(request);
           let contextNode = makeRequireContext(`page!${directory}`, regexp);
           return makeSitegenAPICall('wrapPageContext', [contextNode]);
 
-        } else if (isSitegenAPI('link', node)) {
-          checkSitegenAPI('link', node);
+        } else if (file.isSitegenAPI('link', node, scope)) {
+          checkSitegenAPI('link', node, file);
           let request = node.arguments[0].value;
           let moduleNode = makeRequire(`page-link!${request}`);
           return makeSitegenAPICall('wrapPageLinkModule', [moduleNode]);
 
-        } else if (isSitegenAPI('links', node)) {
-          checkSitegenAPI('links', node);
+        } else if (file.isSitegenAPI('links', node, scope)) {
+          checkSitegenAPI('links', node, file);
           let request = node.arguments[0].value;
           let {directory, regexp} = parseRequest(request);
           let contextNode = makeRequireContext(`page-link!${directory}`, regexp);
           return makeSitegenAPICall('wrapPageLinkContext', [contextNode]);
 
-        } else if (isSitegenAPI('page', node)) {
-          checkSitegenAPI('page', node);
+        } else if (file.isSitegenAPI('page', node, scope)) {
+          checkSitegenAPI('page', node, file);
           let request = node.arguments[0].value;
           let moduleNode = makeRequire(`page-meta!${request}`);
           return makeSitegenAPICall('wrapPageMetaModule', [moduleNode]);
 
-        } else if (isSitegenAPI('pages', node)) {
-          checkSitegenAPI('pages', node);
+        } else if (file.isSitegenAPI('pages', node, scope)) {
+          checkSitegenAPI('pages', node, file);
           let request = node.arguments[0].value;
           let {directory, regexp} = parseRequest(request);
           let contextNode = makeRequireContext(`page-meta!${directory}`, regexp);
@@ -80,6 +86,64 @@ export default function QueryAPIBabelPlugin({Plugin, types: t}) {
       }
     }
   });
+}
+
+function makeSitegenAPIRecognizer(file) {
+
+  let namespaceBinding = null;
+  let moduleBindings = {};
+  let nameMapping = {};
+
+  for (let i = 0; i < file.metadata.modules.imports.length; i++) {
+    let imp = file.metadata.modules.imports[i];
+    if (imp.source !== 'sitegen') {
+      continue;
+    }
+    for (let j = 0; j < imp.specifiers.length; j++) {
+      let specifier = imp.specifiers[j];
+      if (specifier.kind === 'namespace') {
+        namespaceBinding = file.scope.getOwnBinding(specifier.local);
+      } else if (specifier.kind === 'named') {
+        moduleBindings[specifier.local] = file.scope.getOwnBinding(specifier.local);
+        nameMapping[specifier.imported] = specifier.local;
+      }
+    }
+  }
+
+  let moduleHasSitegenAPI = (
+    namespaceBinding !== null ||
+    Object.keys(moduleBindings).length > 0
+  );
+
+  return function isSitegenAPI(name, node, scope) {
+    if (!moduleHasSitegenAPI) {
+      return false;
+    }
+    if (node.type !== 'CallExpression') {
+      return false;
+    }
+    let callee = node.callee;
+    if (callee.type === 'MemberExpression') {
+      if (callee.object.type !== 'Identifier' || callee.property.type !== 'Identifier') {
+        return false;
+      }
+      if (scope.getBinding(callee.object.name) !== namespaceBinding) {
+        return false;
+      }
+      if (callee.property.name !== name) {
+        return false;
+      }
+    } else if (callee.type === 'Identifier') {
+      name = nameMapping[name];
+      if (callee.name !== name) {
+        return false;
+      }
+      if (scope.getBinding(callee.name) !== moduleBindings[callee.name]) {
+        return false;
+      }
+    }
+    return true;
+  }
 }
 
 function parseRequest(request) {
@@ -100,32 +164,17 @@ function parseRequest(request) {
   return {directory, regexp};
 }
 
-function isSitegenAPI(name, node) {
-  return (
-    node.type === 'CallExpression' &&
-    node.callee.type === 'MemberExpression' &&
-    node.callee.object.type === 'Identifier' &&
-    node.callee.object.name === 'Sitegen' &&
-    node.callee.property.type === 'Identifier' &&
-    node.callee.property.name === name
-  );
-}
-
-function checkSitegenAPI(name, node) {
-  invariant(
-    node.arguments.length === 1,
-    'Sitegen.%s(...): only single argument is allowed', name
-  );
-  invariant(
-    node.arguments[0].type === 'Literal',
-    'Sitegen.%s(...): only string literal argument is allowed', name
-  );
-  invariant(
-    node.arguments[0].type === 'Literal',
-    'Sitegen.%s(...): only string literal argument is allowed', name
-  );
-  invariant(
-    typeof node.arguments[0].type === 'string',
-    'Sitegen.%s(...): only string literal argument is allowed', name
-  );
+function checkSitegenAPI(name, node, file) {
+  if (node.arguments.length !== 1) {
+    throw file.errorWithNode(node, `Sitegen.${name}(...): only single argument is allowed`);
+  }
+  if (node.arguments[0].type !== 'Literal') {
+    throw file.errorWithNode(node, `Sitegen.${name}(...): only string literal argument is allowed`);
+  }
+  if (node.arguments[0].type !== 'Literal') {
+    throw file.errorWithNode(node, `Sitegen.${name}(...): only string literal argument is allowed`);
+  }
+  if (typeof node.arguments[0].type !== 'string') {
+    throw file.errorWithNode(node, `Sitegen.${name}(...): only string literal argument is allowed`);
+  }
 }

--- a/src/QueryAPIBabelPlugin.js
+++ b/src/QueryAPIBabelPlugin.js
@@ -95,8 +95,8 @@ function parseRequest(request) {
   if (directory.length > 1) {
     directory = directory.join('/');
   }
-  pattern = new minimatch.Minimatch(request.substring(directory.length + 1));
-  let regexp = pattern.makeRe() || /.+/;
+  pattern = new minimatch.Minimatch('./' + request.substring(directory.length + 1));
+  let regexp = pattern.makeRe();
   return {directory, regexp};
 }
 

--- a/src/QueryAPIBabelPlugin.js
+++ b/src/QueryAPIBabelPlugin.js
@@ -3,8 +3,11 @@ import minimatch from 'minimatch';
 
 export default function QueryAPIBabelPlugin({Plugin, types: t}) {
 
-  function makeRegExpNode(re) {
-    return t.newExpression(t.identifier('RegExp'), [t.literal(re.source)]);
+  function makeRegExpLiteral(re) {
+    return {
+      type: 'Literal',
+      regex: {pattern: re.source, flags: ''}
+    };
   }
 
   function makeSitegenAPICall(name, args) {
@@ -27,7 +30,7 @@ export default function QueryAPIBabelPlugin({Plugin, types: t}) {
     return t.callExpression(callee, [
       t.literal(request),
       t.literal(true),
-      makeRegExpNode(pattern),
+      makeRegExpLiteral(pattern),
     ]);
   }
 

--- a/src/QueryAPIBabelPlugin.js
+++ b/src/QueryAPIBabelPlugin.js
@@ -1,0 +1,142 @@
+import invariant from 'invariant';
+import minimatch from 'minimatch';
+
+export default function QueryAPIBabelPlugin({Plugin, types: t}) {
+
+  function makeRegExpNode(re) {
+    return t.newExpression(t.identifier('RegExp'), [t.literal(re.source)]);
+  }
+
+  function makeSitegenInternalCallExpression(name, args) {
+    let callee = t.memberExpression(
+      t.identifier('Sitegen'),
+      t.identifier('__internal')
+    );
+    callee = t.memberExpression(callee, t.identifier(name));
+    return t.callExpression(callee, args);
+  }
+
+  return new Plugin("sitegen-query-api", {
+    visitor: {
+      CallExpression(node, parent) {
+
+        if (isSitegenAPI('requirePage', node)) {
+          checkSitegenAPI('requirePage', node);
+          let request = node.arguments[0].value;
+          return t.callExpression(
+            t.identifier('require'),
+            [t.literal(`page!${request}`)]
+          );
+
+        } else if (isSitegenAPI('requirePageList', node)) {
+          checkSitegenAPI('requirePageList', node);
+          let request = node.arguments[0].value;
+          let {directory, regexp} = parseRequest(request);
+          return t.callExpression(
+            t.identifier('require.context'),
+            [
+              t.literal(`page!${directory}`),
+              t.literal(true),
+              makeRegExpNode(regexp)
+            ]
+          );
+
+        } else if (isSitegenAPI('getLink', node)) {
+          checkSitegenAPI('getLink', node);
+          let request = node.arguments[0].value;
+          return t.callExpression(
+            t.identifier('require'),
+            [t.literal(`page-link!${request}`)]
+          );
+
+        } else if (isSitegenAPI('getLinkList', node)) {
+          checkSitegenAPI('getLinkList', node);
+          let request = node.arguments[0].value;
+          let {directory, regexp} = parseRequest(request);
+          let contextNode = t.callExpression(
+            t.identifier('require.context'),
+            [
+              t.literal(`page-link!${directory}`),
+              t.literal(true),
+              makeRegExpNode(regexp)
+            ]
+          );
+          return makeSitegenInternalCallExpression(
+            'makeLinkListFromContext',
+            [contextNode]);
+
+        } else if (isSitegenAPI('getMeta', node)) {
+          checkSitegenAPI('getMeta', node);
+          let request = node.arguments[0].value;
+          return t.callExpression(
+            t.identifier('require'),
+            [t.literal(`page-meta!${request}`)]
+          );
+
+        } else if (isSitegenAPI('getMetaList', node)) {
+          checkSitegenAPI('getMetaList', node);
+          let request = node.arguments[0].value;
+          let {directory, regexp} = parseRequest(request);
+          let contextNode = t.callExpression(
+            t.identifier('require.context'),
+            [
+              t.literal(`page-meta!${directory}`),
+              t.literal(true),
+              makeRegExpNode(regexp)
+            ]
+          );
+          return makeSitegenInternalCallExpression(
+            'makeMetaListFromContext',
+            [contextNode]);
+        }
+      }
+    }
+  });
+}
+
+function parseRequest(request) {
+  let pattern = new minimatch.Minimatch(request);
+  let directory = [];
+  for (let i = 0; i < pattern.set[0].length; i++) {
+    if (typeof pattern.set[0][i] === 'string') {
+      directory.push(pattern.set[0][i]);
+    } else {
+      break;
+    }
+  }
+  if (directory.length > 1) {
+    directory = directory.join('/');
+  }
+  pattern = new minimatch.Minimatch(request.substring(directory.length + 1));
+  return {directory, regexp: pattern.makeRe()};
+}
+
+function isSitegenAPI(name, node) {
+  return (
+    node.type === 'CallExpression' &&
+    node.callee.type === 'MemberExpression' &&
+    node.callee.object.type === 'Identifier' &&
+    node.callee.object.name === 'Sitegen' &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === name
+  );
+}
+
+function checkSitegenAPI(name, node) {
+  invariant(
+    node.arguments.length === 1,
+    'Sitegen.%s(...): only single argument is allowed', name
+  );
+  invariant(
+    node.arguments[0].type === 'Literal',
+    'Sitegen.%s(...): only string literal argument is allowed', name
+  );
+  invariant(
+    node.arguments[0].type === 'Literal',
+    'Sitegen.%s(...): only string literal argument is allowed', name
+  );
+  invariant(
+    typeof node.arguments[0].type === 'string',
+    'Sitegen.%s(...): only string literal argument is allowed', name
+  );
+}

--- a/src/QueryAPIBabelPlugin.js
+++ b/src/QueryAPIBabelPlugin.js
@@ -35,40 +35,40 @@ export default function QueryAPIBabelPlugin({Plugin, types: t}) {
     visitor: {
       CallExpression(node) {
 
-        if (isSitegenAPI('requirePage', node)) {
-          checkSitegenAPI('requirePage', node);
+        if (isSitegenAPI('includePage', node)) {
+          checkSitegenAPI('includePage', node);
           let request = node.arguments[0].value;
           let moduleNode = makeRequire(`page!${request}`);
           return makeSitegenAPICall('wrapPageModule', [moduleNode]);
 
-        } else if (isSitegenAPI('requirePageList', node)) {
-          checkSitegenAPI('requirePageList', node);
+        } else if (isSitegenAPI('includePages', node)) {
+          checkSitegenAPI('includePages', node);
           let request = node.arguments[0].value;
           let {directory, regexp} = parseRequest(request);
           let contextNode = makeRequireContext(`page!${directory}`, regexp);
           return makeSitegenAPICall('wrapPageContext', [contextNode]);
 
-        } else if (isSitegenAPI('getLink', node)) {
-          checkSitegenAPI('getLink', node);
+        } else if (isSitegenAPI('link', node)) {
+          checkSitegenAPI('link', node);
           let request = node.arguments[0].value;
           let moduleNode = makeRequire(`page-link!${request}`);
           return makeSitegenAPICall('wrapPageLinkModule', [moduleNode]);
 
-        } else if (isSitegenAPI('getLinkList', node)) {
-          checkSitegenAPI('getLinkList', node);
+        } else if (isSitegenAPI('links', node)) {
+          checkSitegenAPI('links', node);
           let request = node.arguments[0].value;
           let {directory, regexp} = parseRequest(request);
           let contextNode = makeRequireContext(`page-link!${directory}`, regexp);
           return makeSitegenAPICall('wrapPageLinkContext', [contextNode]);
 
-        } else if (isSitegenAPI('getMeta', node)) {
-          checkSitegenAPI('getMeta', node);
+        } else if (isSitegenAPI('page', node)) {
+          checkSitegenAPI('page', node);
           let request = node.arguments[0].value;
           let moduleNode = makeRequire(`page-meta!${request}`);
           return makeSitegenAPICall('wrapPageMetaModule', [moduleNode]);
 
-        } else if (isSitegenAPI('getMetaList', node)) {
-          checkSitegenAPI('getMetaList', node);
+        } else if (isSitegenAPI('pages', node)) {
+          checkSitegenAPI('pages', node);
           let request = node.arguments[0].value;
           let {directory, regexp} = parseRequest(request);
           let contextNode = makeRequireContext(`page-meta!${directory}`, regexp);

--- a/src/__tests__/QueryAPIBabelPlugin-test.js
+++ b/src/__tests__/QueryAPIBabelPlugin-test.js
@@ -1,0 +1,105 @@
+import assert                         from 'power-assert';
+import {transform as babelTransform}  from 'babel';
+import QueryAPIBabelPlugin            from '../QueryAPIBabelPlugin';
+
+function transform(code) {
+  let res = babelTransform(code, {plugins: [QueryAPIBabelPlugin]})
+  return res.code.split('\n').filter(Boolean);
+}
+
+describe('QueryAPIBabelPlugin', function() {
+
+  it('transforms Sitegen.requirePage', function() {
+    assert.equal(
+      transform('Sitegen.requirePage("./page")')[1],
+      'Sitegen.__internal.wrapPageModule(require("page!./page"));'
+    );
+    assert.throws(function() {
+      transform('Sitegen.requirePage(x)');
+    }, 'Invariant Violation: Sitegen.requirePage(...): only string literal argument is allowed');
+    assert.throws(function() {
+      transform('Sitegen.requirePage("x", 1)');
+    }, 'Invariant Violation: Sitegen.requirePage(...): only string literal argument is allowed');
+  });
+
+  it('transforms Sitegen.getLink', function() {
+    assert.equal(
+      transform('Sitegen.getLink("./page")')[1],
+      'Sitegen.__internal.wrapPageLinkModule(require("page-link!./page"));'
+    );
+    assert.throws(function() {
+      transform('Sitegen.getLink(x)');
+    }, 'Invariant Violation: Sitegen.getLink(...): only string literal argument is allowed');
+    assert.throws(function() {
+      transform('Sitegen.getLink("x", 1)');
+    }, 'Invariant Violation: Sitegen.getLink(...): only string literal argument is allowed');
+  });
+
+  it('transforms Sitegen.getMeta', function() {
+    assert.equal(
+      transform('Sitegen.getMeta("./page")')[1],
+      'Sitegen.__internal.wrapPageMetaModule(require("page-meta!./page"));'
+    );
+    assert.throws(function() {
+      transform('Sitegen.getMeta(x)');
+    }, 'Invariant Violation: Sitegen.getMeta(...): only string literal argument is allowed');
+    assert.throws(function() {
+      transform('Sitegen.getMeta("x", 1)');
+    }, 'Invariant Violation: Sitegen.getMeta(...): only string literal argument is allowed');
+  });
+
+  it('transforms Sitegen.requirePageList', function() {
+    assert.equal(
+      transform('Sitegen.requirePageList("./page")')[1],
+      'Sitegen.__internal.wrapPageContext(require.context("page!./page", true, new RegExp(".+")));'
+    );
+    assert.equal(
+      transform('Sitegen.requirePageList("./page/*.md")')[1],
+      'Sitegen.__internal.wrapPageContext(require.context("page!./page", true, new RegExp("^(?:(?!\\\\.)(?=.)[^\\\\/]*?\\\\.md)$")));'
+    );
+
+    assert.throws(function() {
+      transform('Sitegen.requirePageList(x)');
+    }, 'Invariant Violation: Sitegen.requirePageList(...): only string literal argument is allowed');
+    assert.throws(function() {
+      transform('Sitegen.requirePageList("x", 1)');
+    }, 'Invariant Violation: Sitegen.requirePageList(...): only string literal argument is allowed');
+  });
+
+  it('transforms Sitegen.getLinkList', function() {
+    assert.equal(
+      transform('Sitegen.getLinkList("./page")')[1],
+      'Sitegen.__internal.wrapPageLinkContext(require.context("page-link!./page", true, new RegExp(".+")));'
+    );
+    assert.equal(
+      transform('Sitegen.getLinkList("./page/*.md")')[1],
+      'Sitegen.__internal.wrapPageLinkContext(require.context("page-link!./page", true, new RegExp("^(?:(?!\\\\.)(?=.)[^\\\\/]*?\\\\.md)$")));'
+    );
+
+    assert.throws(function() {
+      transform('Sitegen.getLinkList(x)');
+    }, 'Invariant Violation: Sitegen.getLinkList(...): only string literal argument is allowed');
+    assert.throws(function() {
+      transform('Sitegen.getLinkList("x", 1)');
+    }, 'Invariant Violation: Sitegen.getLinkList(...): only string literal argument is allowed');
+  });
+
+  it('transforms Sitegen.getMetaList', function() {
+    assert.equal(
+      transform('Sitegen.getMetaList("./page")')[1],
+      'Sitegen.__internal.wrapPageMetaContext(require.context("page-meta!./page", true, new RegExp(".+")));'
+    );
+    assert.equal(
+      transform('Sitegen.getMetaList("./page/*.md")')[1],
+      'Sitegen.__internal.wrapPageMetaContext(require.context("page-meta!./page", true, new RegExp("^(?:(?!\\\\.)(?=.)[^\\\\/]*?\\\\.md)$")));'
+    );
+
+    assert.throws(function() {
+      transform('Sitegen.getMetaList(x)');
+    }, 'Invariant Violation: Sitegen.getMetaList(...): only string literal argument is allowed');
+    assert.throws(function() {
+      transform('Sitegen.getMetaList("x", 1)');
+    }, 'Invariant Violation: Sitegen.getMetaList(...): only string literal argument is allowed');
+  });
+
+});

--- a/src/__tests__/QueryAPIBabelPlugin-test.js
+++ b/src/__tests__/QueryAPIBabelPlugin-test.js
@@ -51,11 +51,11 @@ describe('QueryAPIBabelPlugin', function() {
   it('transforms Sitegen.includePages', function() {
     assert.equal(
       transform('Sitegen.includePages("./page")')[1],
-      'Sitegen.__internal.wrapPageContext(require.context("page!./page", true, new RegExp(".+")));'
+      'Sitegen.__internal.wrapPageContext(require.context("page!./page", true, /.+/));'
     );
     assert.equal(
       transform('Sitegen.includePages("./page/*.md")')[1],
-      'Sitegen.__internal.wrapPageContext(require.context("page!./page", true, new RegExp("^(?:(?!\\\\.)(?=.)[^\\\\/]*?\\\\.md)$")));'
+      'Sitegen.__internal.wrapPageContext(require.context("page!./page", true, /^(?:(?!\\.)(?=.)[^\\/]*?\\.md)$/));'
     );
 
     assert.throws(function() {
@@ -69,11 +69,11 @@ describe('QueryAPIBabelPlugin', function() {
   it('transforms Sitegen.links', function() {
     assert.equal(
       transform('Sitegen.links("./page")')[1],
-      'Sitegen.__internal.wrapPageLinkContext(require.context("page-link!./page", true, new RegExp(".+")));'
+      'Sitegen.__internal.wrapPageLinkContext(require.context("page-link!./page", true, /.+/));'
     );
     assert.equal(
       transform('Sitegen.links("./page/*.md")')[1],
-      'Sitegen.__internal.wrapPageLinkContext(require.context("page-link!./page", true, new RegExp("^(?:(?!\\\\.)(?=.)[^\\\\/]*?\\\\.md)$")));'
+      'Sitegen.__internal.wrapPageLinkContext(require.context("page-link!./page", true, /^(?:(?!\\.)(?=.)[^\\/]*?\\.md)$/));'
     );
 
     assert.throws(function() {
@@ -87,11 +87,11 @@ describe('QueryAPIBabelPlugin', function() {
   it('transforms Sitegen.pages', function() {
     assert.equal(
       transform('Sitegen.pages("./page")')[1],
-      'Sitegen.__internal.wrapPageMetaContext(require.context("page-meta!./page", true, new RegExp(".+")));'
+      'Sitegen.__internal.wrapPageMetaContext(require.context("page-meta!./page", true, /.+/));'
     );
     assert.equal(
       transform('Sitegen.pages("./page/*.md")')[1],
-      'Sitegen.__internal.wrapPageMetaContext(require.context("page-meta!./page", true, new RegExp("^(?:(?!\\\\.)(?=.)[^\\\\/]*?\\\\.md)$")));'
+      'Sitegen.__internal.wrapPageMetaContext(require.context("page-meta!./page", true, /^(?:(?!\\.)(?=.)[^\\/]*?\\.md)$/));'
     );
 
     assert.throws(function() {

--- a/src/__tests__/QueryAPIBabelPlugin-test.js
+++ b/src/__tests__/QueryAPIBabelPlugin-test.js
@@ -51,11 +51,11 @@ describe('QueryAPIBabelPlugin', function() {
   it('transforms Sitegen.includePages', function() {
     assert.equal(
       transform('Sitegen.includePages("./page")')[1],
-      'Sitegen.__internal.wrapPageContext(require.context("page!./page", true, /.+/));'
+      'Sitegen.__internal.wrapPageContext(require.context("page!./page", true, /^(?:\\.\\/)$/));'
     );
     assert.equal(
       transform('Sitegen.includePages("./page/*.md")')[1],
-      'Sitegen.__internal.wrapPageContext(require.context("page!./page", true, /^(?:(?!\\.)(?=.)[^\\/]*?\\.md)$/));'
+      'Sitegen.__internal.wrapPageContext(require.context("page!./page", true, /^(?:\\.\\/(?!\\.)(?=.)[^\\/]*?\\.md)$/));'
     );
 
     assert.throws(function() {
@@ -69,11 +69,11 @@ describe('QueryAPIBabelPlugin', function() {
   it('transforms Sitegen.links', function() {
     assert.equal(
       transform('Sitegen.links("./page")')[1],
-      'Sitegen.__internal.wrapPageLinkContext(require.context("page-link!./page", true, /.+/));'
+      'Sitegen.__internal.wrapPageLinkContext(require.context("page-link!./page", true, /^(?:\\.\\/)$/));'
     );
     assert.equal(
       transform('Sitegen.links("./page/*.md")')[1],
-      'Sitegen.__internal.wrapPageLinkContext(require.context("page-link!./page", true, /^(?:(?!\\.)(?=.)[^\\/]*?\\.md)$/));'
+      'Sitegen.__internal.wrapPageLinkContext(require.context("page-link!./page", true, /^(?:\\.\\/(?!\\.)(?=.)[^\\/]*?\\.md)$/));'
     );
 
     assert.throws(function() {
@@ -87,11 +87,11 @@ describe('QueryAPIBabelPlugin', function() {
   it('transforms Sitegen.pages', function() {
     assert.equal(
       transform('Sitegen.pages("./page")')[1],
-      'Sitegen.__internal.wrapPageMetaContext(require.context("page-meta!./page", true, /.+/));'
+      'Sitegen.__internal.wrapPageMetaContext(require.context("page-meta!./page", true, /^(?:\\.\\/)$/));'
     );
     assert.equal(
       transform('Sitegen.pages("./page/*.md")')[1],
-      'Sitegen.__internal.wrapPageMetaContext(require.context("page-meta!./page", true, /^(?:(?!\\.)(?=.)[^\\/]*?\\.md)$/));'
+      'Sitegen.__internal.wrapPageMetaContext(require.context("page-meta!./page", true, /^(?:\\.\\/(?!\\.)(?=.)[^\\/]*?\\.md)$/));'
     );
 
     assert.throws(function() {

--- a/src/__tests__/QueryAPIBabelPlugin-test.js
+++ b/src/__tests__/QueryAPIBabelPlugin-test.js
@@ -2,103 +2,221 @@ import assert                         from 'power-assert';
 import {transform as babelTransform}  from 'babel';
 import QueryAPIBabelPlugin            from '../QueryAPIBabelPlugin';
 
-function transform(code) {
+function transformMulti(code) {
   let res = babelTransform(code, {plugins: [QueryAPIBabelPlugin]})
-  return res.code.split('\n').filter(Boolean);
+  let lines = res.code.split('\n').filter(Boolean);
+  return lines;
+}
+
+function transform(code) {
+  let lines = transformMulti(code);
+  return lines[lines.length - 1];
 }
 
 describe('QueryAPIBabelPlugin', function() {
 
   it('transforms Sitegen.includePage', function() {
     assert.equal(
-      transform('Sitegen.includePage("./page")')[1],
-      'Sitegen.__internal.wrapPageModule(require("page!./page"));'
+      transform('import * as Sitegen from "sitegen";\nSitegen.includePage("./page")'),
+      'require("sitegen/internal").wrapPageModule(require("page!./page"));'
     );
+    assert.equal(
+      transform('import {includePage} from "sitegen";\nincludePage("./page")'),
+      'require("sitegen/internal").wrapPageModule(require("page!./page"));'
+    );
+    assert.equal(
+      transformMulti('import {includePage} from "sitegen";\n{includePage("./page")}')[3],
+      '  require("sitegen/internal").wrapPageModule(require("page!./page"));'
+    );
+    assert.equal(
+      transform('import {includePage as include} from "sitegen";\ninclude("./page")'),
+      'require("sitegen/internal").wrapPageModule(require("page!./page"));'
+    );
+
+    assert.equal(
+      transform('Sitegen.includePage("./page")'),
+      'Sitegen.includePage("./page");'
+    );
+    assert.equal(
+      transform('includePage("./page")'),
+      'includePage("./page");'
+    );
+
     assert.throws(function() {
-      transform('Sitegen.includePage(x)');
+      transform('import * as Sitegen from "sitegen";\nSitegen.includePage(x)');
     }, 'Invariant Violation: Sitegen.includePage(...): only string literal argument is allowed');
     assert.throws(function() {
-      transform('Sitegen.includePage("x", 1)');
+      transform('import * as Sitegen from "sitegen";\nSitegen.includePage("x", 1)');
     }, 'Invariant Violation: Sitegen.includePage(...): only string literal argument is allowed');
   });
 
   it('transforms Sitegen.link', function() {
     assert.equal(
-      transform('Sitegen.link("./page")')[1],
-      'Sitegen.__internal.wrapPageLinkModule(require("page-link!./page"));'
+      transform('import * as Sitegen from "sitegen";\nSitegen.link("./page")'),
+      'require("sitegen/internal").wrapPageLinkModule(require("page-link!./page"));'
     );
+    assert.equal(
+      transform('import {link} from "sitegen";\nlink("./page")'),
+      'require("sitegen/internal").wrapPageLinkModule(require("page-link!./page"));'
+    );
+    assert.equal(
+      transform('import {link as l} from "sitegen";\nl("./page")'),
+      'require("sitegen/internal").wrapPageLinkModule(require("page-link!./page"));'
+    );
+
+    assert.equal(
+      transform('Sitegen.link("./page")'),
+      'Sitegen.link("./page");'
+    );
+    assert.equal(
+      transform('link("./page")'),
+      'link("./page");'
+    );
+
     assert.throws(function() {
-      transform('Sitegen.link(x)');
+      transform('import * as Sitegen from "sitegen";\nSitegen.link(x)');
     }, 'Invariant Violation: Sitegen.link(...): only string literal argument is allowed');
     assert.throws(function() {
-      transform('Sitegen.link("x", 1)');
+      transform('import * as Sitegen from "sitegen";\nSitegen.link("x", 1)');
     }, 'Invariant Violation: Sitegen.link(...): only string literal argument is allowed');
   });
 
   it('transforms Sitegen.page', function() {
     assert.equal(
-      transform('Sitegen.page("./page")')[1],
-      'Sitegen.__internal.wrapPageMetaModule(require("page-meta!./page"));'
+      transform('import * as Sitegen from "sitegen";\nSitegen.page("./page")'),
+      'require("sitegen/internal").wrapPageMetaModule(require("page-meta!./page"));'
     );
+    assert.equal(
+      transform('import {page} from "sitegen";\npage("./page")'),
+      'require("sitegen/internal").wrapPageMetaModule(require("page-meta!./page"));'
+    );
+    assert.equal(
+      transform('import {page as p} from "sitegen";\np("./page")'),
+      'require("sitegen/internal").wrapPageMetaModule(require("page-meta!./page"));'
+    );
+
+    assert.equal(
+      transform('Sitegen.page("./page")'),
+      'Sitegen.page("./page");'
+    );
+    assert.equal(
+      transform('page("./page")'),
+      'page("./page");'
+    );
+
     assert.throws(function() {
-      transform('Sitegen.page(x)');
+      transform('import * as Sitegen from "sitegen";\nSitegen.page(x)');
     }, 'Invariant Violation: Sitegen.page(...): only string literal argument is allowed');
     assert.throws(function() {
-      transform('Sitegen.page("x", 1)');
+      transform('import * as Sitegen from "sitegen";\nSitegen.page("x", 1)');
     }, 'Invariant Violation: Sitegen.page(...): only string literal argument is allowed');
   });
 
   it('transforms Sitegen.includePages', function() {
     assert.equal(
-      transform('Sitegen.includePages("./page")')[1],
-      'Sitegen.__internal.wrapPageContext(require.context("page!./page", true, /^(?:\\.\\/)$/));'
+      transform('import * as Sitegen from "sitegen";\nSitegen.includePages("./page")'),
+      'require("sitegen/internal").wrapPageContext(require.context("page!./page", true, /^(?:\\.\\/)$/));'
     );
     assert.equal(
-      transform('Sitegen.includePages("./page/*.md")')[1],
-      'Sitegen.__internal.wrapPageContext(require.context("page!./page", true, /^(?:\\.\\/(?!\\.)(?=.)[^\\/]*?\\.md)$/));'
+      transform('import {includePages} from "sitegen";\nincludePages("./page")'),
+      'require("sitegen/internal").wrapPageContext(require.context("page!./page", true, /^(?:\\.\\/)$/));'
+    );
+    assert.equal(
+      transform('import {includePages as include} from "sitegen";\ninclude("./page")'),
+      'require("sitegen/internal").wrapPageContext(require.context("page!./page", true, /^(?:\\.\\/)$/));'
+    );
+
+    assert.equal(
+      transform('Sitegen.includePages("./page")'),
+      'Sitegen.includePages("./page");'
+    );
+    assert.equal(
+      transform('includePages("./page")'),
+      'includePages("./page");'
+    );
+
+    assert.equal(
+      transform('import * as Sitegen from "sitegen";\nSitegen.includePages("./page/*.md")'),
+      'require("sitegen/internal").wrapPageContext(require.context("page!./page", true, /^(?:\\.\\/(?!\\.)(?=.)[^\\/]*?\\.md)$/));'
     );
 
     assert.throws(function() {
-      transform('Sitegen.includePages(x)');
+      transform('import * as Sitegen from "sitegen";\nSitegen.includePages(x)');
     }, 'Invariant Violation: Sitegen.includePages(...): only string literal argument is allowed');
     assert.throws(function() {
-      transform('Sitegen.includePages("x", 1)');
+      transform('import * as Sitegen from "sitegen";\nSitegen.includePages("x", 1)');
     }, 'Invariant Violation: Sitegen.includePages(...): only string literal argument is allowed');
   });
 
   it('transforms Sitegen.links', function() {
     assert.equal(
-      transform('Sitegen.links("./page")')[1],
-      'Sitegen.__internal.wrapPageLinkContext(require.context("page-link!./page", true, /^(?:\\.\\/)$/));'
+      transform('import * as Sitegen from "sitegen";\nSitegen.links("./page")'),
+      'require("sitegen/internal").wrapPageLinkContext(require.context("page-link!./page", true, /^(?:\\.\\/)$/));'
     );
     assert.equal(
-      transform('Sitegen.links("./page/*.md")')[1],
-      'Sitegen.__internal.wrapPageLinkContext(require.context("page-link!./page", true, /^(?:\\.\\/(?!\\.)(?=.)[^\\/]*?\\.md)$/));'
+      transform('import {links} from "sitegen";\nlinks("./page")'),
+      'require("sitegen/internal").wrapPageLinkContext(require.context("page-link!./page", true, /^(?:\\.\\/)$/));'
+    );
+    assert.equal(
+      transform('import {links as l} from "sitegen";\nl("./page")'),
+      'require("sitegen/internal").wrapPageLinkContext(require.context("page-link!./page", true, /^(?:\\.\\/)$/));'
+    );
+
+    assert.equal(
+      transform('Sitegen.links("./page")'),
+      'Sitegen.links("./page");'
+    );
+    assert.equal(
+      transform('links("./page")'),
+      'links("./page");'
+    );
+
+    assert.equal(
+      transform('import * as Sitegen from "sitegen";\nSitegen.links("./page/*.md")'),
+      'require("sitegen/internal").wrapPageLinkContext(require.context("page-link!./page", true, /^(?:\\.\\/(?!\\.)(?=.)[^\\/]*?\\.md)$/));'
     );
 
     assert.throws(function() {
-      transform('Sitegen.links(x)');
+      transform('import * as Sitegen from "sitegen";\nSitegen.links(x)');
     }, 'Invariant Violation: Sitegen.links(...): only string literal argument is allowed');
     assert.throws(function() {
-      transform('Sitegen.links("x", 1)');
+      transform('import * as Sitegen from "sitegen";\nSitegen.links("x", 1)');
     }, 'Invariant Violation: Sitegen.links(...): only string literal argument is allowed');
   });
 
   it('transforms Sitegen.pages', function() {
     assert.equal(
-      transform('Sitegen.pages("./page")')[1],
-      'Sitegen.__internal.wrapPageMetaContext(require.context("page-meta!./page", true, /^(?:\\.\\/)$/));'
+      transform('import * as Sitegen from "sitegen";\nSitegen.pages("./page")'),
+      'require("sitegen/internal").wrapPageMetaContext(require.context("page-meta!./page", true, /^(?:\\.\\/)$/));'
     );
     assert.equal(
-      transform('Sitegen.pages("./page/*.md")')[1],
-      'Sitegen.__internal.wrapPageMetaContext(require.context("page-meta!./page", true, /^(?:\\.\\/(?!\\.)(?=.)[^\\/]*?\\.md)$/));'
+      transform('import {pages} from "sitegen";\npages("./page")'),
+      'require("sitegen/internal").wrapPageMetaContext(require.context("page-meta!./page", true, /^(?:\\.\\/)$/));'
+    );
+    assert.equal(
+      transform('import {pages as p} from "sitegen";\np("./page")'),
+      'require("sitegen/internal").wrapPageMetaContext(require.context("page-meta!./page", true, /^(?:\\.\\/)$/));'
+    );
+
+    assert.equal(
+      transform('Sitegen.pages("./page")'),
+      'Sitegen.pages("./page");'
+    );
+    assert.equal(
+      transform('pages("./page")'),
+      'pages("./page");'
+    );
+
+    assert.equal(
+      transform('import * as Sitegen from "sitegen";\nSitegen.pages("./page/*.md")'),
+      'require("sitegen/internal").wrapPageMetaContext(require.context("page-meta!./page", true, /^(?:\\.\\/(?!\\.)(?=.)[^\\/]*?\\.md)$/));'
     );
 
     assert.throws(function() {
-      transform('Sitegen.pages(x)');
+      transform('import * as Sitegen from "sitegen";\nSitegen.pages(x)');
     }, 'Invariant Violation: Sitegen.pages(...): only string literal argument is allowed');
     assert.throws(function() {
-      transform('Sitegen.pages("x", 1)');
+      transform('import * as Sitegen from "sitegen";\nSitegen.pages("x", 1)');
     }, 'Invariant Violation: Sitegen.pages(...): only string literal argument is allowed');
   });
 

--- a/src/__tests__/QueryAPIBabelPlugin-test.js
+++ b/src/__tests__/QueryAPIBabelPlugin-test.js
@@ -9,97 +9,97 @@ function transform(code) {
 
 describe('QueryAPIBabelPlugin', function() {
 
-  it('transforms Sitegen.requirePage', function() {
+  it('transforms Sitegen.includePage', function() {
     assert.equal(
-      transform('Sitegen.requirePage("./page")')[1],
+      transform('Sitegen.includePage("./page")')[1],
       'Sitegen.__internal.wrapPageModule(require("page!./page"));'
     );
     assert.throws(function() {
-      transform('Sitegen.requirePage(x)');
-    }, 'Invariant Violation: Sitegen.requirePage(...): only string literal argument is allowed');
+      transform('Sitegen.includePage(x)');
+    }, 'Invariant Violation: Sitegen.includePage(...): only string literal argument is allowed');
     assert.throws(function() {
-      transform('Sitegen.requirePage("x", 1)');
-    }, 'Invariant Violation: Sitegen.requirePage(...): only string literal argument is allowed');
+      transform('Sitegen.includePage("x", 1)');
+    }, 'Invariant Violation: Sitegen.includePage(...): only string literal argument is allowed');
   });
 
-  it('transforms Sitegen.getLink', function() {
+  it('transforms Sitegen.link', function() {
     assert.equal(
-      transform('Sitegen.getLink("./page")')[1],
+      transform('Sitegen.link("./page")')[1],
       'Sitegen.__internal.wrapPageLinkModule(require("page-link!./page"));'
     );
     assert.throws(function() {
-      transform('Sitegen.getLink(x)');
-    }, 'Invariant Violation: Sitegen.getLink(...): only string literal argument is allowed');
+      transform('Sitegen.link(x)');
+    }, 'Invariant Violation: Sitegen.link(...): only string literal argument is allowed');
     assert.throws(function() {
-      transform('Sitegen.getLink("x", 1)');
-    }, 'Invariant Violation: Sitegen.getLink(...): only string literal argument is allowed');
+      transform('Sitegen.link("x", 1)');
+    }, 'Invariant Violation: Sitegen.link(...): only string literal argument is allowed');
   });
 
-  it('transforms Sitegen.getMeta', function() {
+  it('transforms Sitegen.page', function() {
     assert.equal(
-      transform('Sitegen.getMeta("./page")')[1],
+      transform('Sitegen.page("./page")')[1],
       'Sitegen.__internal.wrapPageMetaModule(require("page-meta!./page"));'
     );
     assert.throws(function() {
-      transform('Sitegen.getMeta(x)');
-    }, 'Invariant Violation: Sitegen.getMeta(...): only string literal argument is allowed');
+      transform('Sitegen.page(x)');
+    }, 'Invariant Violation: Sitegen.page(...): only string literal argument is allowed');
     assert.throws(function() {
-      transform('Sitegen.getMeta("x", 1)');
-    }, 'Invariant Violation: Sitegen.getMeta(...): only string literal argument is allowed');
+      transform('Sitegen.page("x", 1)');
+    }, 'Invariant Violation: Sitegen.page(...): only string literal argument is allowed');
   });
 
-  it('transforms Sitegen.requirePageList', function() {
+  it('transforms Sitegen.includePages', function() {
     assert.equal(
-      transform('Sitegen.requirePageList("./page")')[1],
+      transform('Sitegen.includePages("./page")')[1],
       'Sitegen.__internal.wrapPageContext(require.context("page!./page", true, new RegExp(".+")));'
     );
     assert.equal(
-      transform('Sitegen.requirePageList("./page/*.md")')[1],
+      transform('Sitegen.includePages("./page/*.md")')[1],
       'Sitegen.__internal.wrapPageContext(require.context("page!./page", true, new RegExp("^(?:(?!\\\\.)(?=.)[^\\\\/]*?\\\\.md)$")));'
     );
 
     assert.throws(function() {
-      transform('Sitegen.requirePageList(x)');
-    }, 'Invariant Violation: Sitegen.requirePageList(...): only string literal argument is allowed');
+      transform('Sitegen.includePages(x)');
+    }, 'Invariant Violation: Sitegen.includePages(...): only string literal argument is allowed');
     assert.throws(function() {
-      transform('Sitegen.requirePageList("x", 1)');
-    }, 'Invariant Violation: Sitegen.requirePageList(...): only string literal argument is allowed');
+      transform('Sitegen.includePages("x", 1)');
+    }, 'Invariant Violation: Sitegen.includePages(...): only string literal argument is allowed');
   });
 
-  it('transforms Sitegen.getLinkList', function() {
+  it('transforms Sitegen.links', function() {
     assert.equal(
-      transform('Sitegen.getLinkList("./page")')[1],
+      transform('Sitegen.links("./page")')[1],
       'Sitegen.__internal.wrapPageLinkContext(require.context("page-link!./page", true, new RegExp(".+")));'
     );
     assert.equal(
-      transform('Sitegen.getLinkList("./page/*.md")')[1],
+      transform('Sitegen.links("./page/*.md")')[1],
       'Sitegen.__internal.wrapPageLinkContext(require.context("page-link!./page", true, new RegExp("^(?:(?!\\\\.)(?=.)[^\\\\/]*?\\\\.md)$")));'
     );
 
     assert.throws(function() {
-      transform('Sitegen.getLinkList(x)');
-    }, 'Invariant Violation: Sitegen.getLinkList(...): only string literal argument is allowed');
+      transform('Sitegen.links(x)');
+    }, 'Invariant Violation: Sitegen.links(...): only string literal argument is allowed');
     assert.throws(function() {
-      transform('Sitegen.getLinkList("x", 1)');
-    }, 'Invariant Violation: Sitegen.getLinkList(...): only string literal argument is allowed');
+      transform('Sitegen.links("x", 1)');
+    }, 'Invariant Violation: Sitegen.links(...): only string literal argument is allowed');
   });
 
-  it('transforms Sitegen.getMetaList', function() {
+  it('transforms Sitegen.pages', function() {
     assert.equal(
-      transform('Sitegen.getMetaList("./page")')[1],
+      transform('Sitegen.pages("./page")')[1],
       'Sitegen.__internal.wrapPageMetaContext(require.context("page-meta!./page", true, new RegExp(".+")));'
     );
     assert.equal(
-      transform('Sitegen.getMetaList("./page/*.md")')[1],
+      transform('Sitegen.pages("./page/*.md")')[1],
       'Sitegen.__internal.wrapPageMetaContext(require.context("page-meta!./page", true, new RegExp("^(?:(?!\\\\.)(?=.)[^\\\\/]*?\\\\.md)$")));'
     );
 
     assert.throws(function() {
-      transform('Sitegen.getMetaList(x)');
-    }, 'Invariant Violation: Sitegen.getMetaList(...): only string literal argument is allowed');
+      transform('Sitegen.pages(x)');
+    }, 'Invariant Violation: Sitegen.pages(...): only string literal argument is allowed');
     assert.throws(function() {
-      transform('Sitegen.getMetaList("x", 1)');
-    }, 'Invariant Violation: Sitegen.getMetaList(...): only string literal argument is allowed');
+      transform('Sitegen.pages("x", 1)');
+    }, 'Invariant Violation: Sitegen.pages(...): only string literal argument is allowed');
   });
 
 });

--- a/src/createWebpackConfig.js
+++ b/src/createWebpackConfig.js
@@ -55,8 +55,9 @@ export default function createWebpackConfig(options = {}) {
     plugins: plugins.filter(Boolean),
     resolve: {
       alias: {
-        sitegen: require.resolve('./'),
-        site: options.lib,
+        'sitegen/internal': require.resolve('./internal'),
+        'sitegen': require.resolve('./'),
+        'site': options.lib,
       },
     },
     resolveLoader: {

--- a/src/createWebpackConfig.js
+++ b/src/createWebpackConfig.js
@@ -1,7 +1,8 @@
-import webpack            from 'webpack';
-import ExtractTextPlugin  from 'extract-text-webpack-plugin';
-import RenderStaticPlugin from './RenderStaticPlugin';
-import LogProgressPlugin  from './LogProgressPlugin';
+import webpack              from 'webpack';
+import ExtractTextPlugin    from 'extract-text-webpack-plugin';
+import RenderStaticPlugin   from './RenderStaticPlugin';
+import LogProgressPlugin    from './LogProgressPlugin';
+import QueryAPIBabelPlugin  from './QueryAPIBabelPlugin';
 
 export let JS_BUNDLE_NAME = '_bootstrap.js';
 export let CSS_BUNDLE_NAME = '_bootstrap.css';
@@ -25,7 +26,8 @@ export default function createWebpackConfig(options = {}) {
     devtool: options.dev ? 'cheap-module-eval-source-map' : undefined,
     babel: options.mode === 'serve' && options.dev && {
       plugins: [
-        'react-transform'
+        QueryAPIBabelPlugin,
+        'react-transform',
       ],
       extra: {
         'react-transform': [{

--- a/src/createWebpackConfig.js
+++ b/src/createWebpackConfig.js
@@ -61,9 +61,9 @@ export default function createWebpackConfig(options = {}) {
     plugins: plugins.filter(Boolean),
     resolve: {
       alias: {
-        'sitegen/internal': require.resolve('./internal'),
-        'sitegen': require.resolve('./'),
-        'site': options.lib,
+        ['sitegen/internal']: require.resolve('./internal'),
+        ['sitegen']: require.resolve('./'),
+        ['site']: options.lib,
       },
     },
     resolveLoader: {

--- a/src/createWebpackConfig.js
+++ b/src/createWebpackConfig.js
@@ -8,27 +8,33 @@ export let JS_BUNDLE_NAME = '_bootstrap.js';
 export let CSS_BUNDLE_NAME = '_bootstrap.css';
 
 export default function createWebpackConfig(options = {}) {
+  let build = options.mode === 'build' && !options.dev;
+  let serve = options.mode === 'serve' && !options.dev;
+  let serveDev = options.mode === 'serve' && options.dev;
+
   let plugins = [
     new LogProgressPlugin(options.compilerName),
-    options.mode === 'build' && new RenderStaticPlugin(),
-    options.mode === 'serve' && options.dev && new webpack.optimize.OccurenceOrderPlugin(),
-    options.mode === 'serve' && options.dev && new webpack.HotModuleReplacementPlugin(),
-    options.mode === 'serve' && options.dev && new webpack.NoErrorsPlugin(),
-    !options.dev && new ExtractTextPlugin(CSS_BUNDLE_NAME),
+    build && new RenderStaticPlugin(),
+    serveDev && new webpack.optimize.OccurenceOrderPlugin(),
+    serveDev && new webpack.HotModuleReplacementPlugin(),
+    serveDev && new webpack.NoErrorsPlugin(),
+    (build || serve) && new ExtractTextPlugin(CSS_BUNDLE_NAME),
   ];
+
   let entry = [
-    options.mode === 'serve' && options.dev && 'webpack-hot-middleware/client?reload=true',
+    serveDev && 'webpack-hot-middleware/client?reload=true',
   ].concat(options.entry);
+
   return {
     entry: entry.filter(Boolean),
-    target: options.mode === 'build' ? 'node' : 'web',
+    target: build ? 'node' : 'web',
     sitegen: options,
-    devtool: options.dev ? 'cheap-module-eval-source-map' : undefined,
-    babel: options.mode === 'serve' && options.dev && {
+    devtool: serveDev ? 'cheap-module-eval-source-map' : undefined,
+    babel: {
       plugins: [
         QueryAPIBabelPlugin,
-        'react-transform',
-      ],
+        serveDev ? 'react-transform' : null
+      ].filter(Boolean),
       extra: {
         'react-transform': [{
           target: 'react-transform-hmr',
@@ -47,7 +53,7 @@ export default function createWebpackConfig(options = {}) {
     output: {
       publicPath: options.publicPath || '/',
       library: 'SitegenSite',
-      libraryTarget: options.mode === 'build' ? 'commonjs2' : 'var',
+      libraryTarget: build ? 'commonjs2' : 'var',
       path: options.output,
       filename: JS_BUNDLE_NAME,
       chunkFilename: '[name].js',

--- a/src/index.js
+++ b/src/index.js
@@ -3,24 +3,3 @@ export createPage         from './createPage';
 export createSite         from './createSite';
 export PageLink           from './PageLink';
 export * as LinkRegistry  from './LinkRegistry';
-
-export default {
-  __internal: {
-
-    wrapPageModule(module) {
-      return module;
-    },
-
-    wrapPageContext(context) {
-      return context;
-    },
-
-    wrapPageLinkModule(module) {
-      return module;
-    },
-
-    wrapPageLinkContext(context) {
-      return context.keys().map(key => context(key));
-    }
-  }
-}

--- a/src/index.js
+++ b/src/index.js
@@ -3,3 +3,24 @@ export createPage         from './createPage';
 export createSite         from './createSite';
 export PageLink           from './PageLink';
 export * as LinkRegistry  from './LinkRegistry';
+
+export default {
+  __internal: {
+
+    wrapPageModule(module) {
+      return module;
+    },
+
+    wrapPageContext(context) {
+      return context;
+    },
+
+    wrapPageLinkModule(module) {
+      return module;
+    },
+
+    wrapPageLinkContext(context) {
+      return context.keys().map(key => context(key));
+    }
+  }
+}

--- a/src/internal.js
+++ b/src/internal.js
@@ -1,0 +1,17 @@
+export default {
+  wrapPageModule(module) {
+    return module;
+  },
+
+  wrapPageContext(context) {
+    return context;
+  },
+
+  wrapPageLinkModule(module) {
+    return module;
+  },
+
+  wrapPageLinkContext(context) {
+    return context.keys().map(key => context(key));
+  }
+}

--- a/src/internal.js
+++ b/src/internal.js
@@ -14,4 +14,4 @@ export default {
   wrapPageLinkContext(context) {
     return context.keys().map(key => context(key));
   }
-}
+};


### PR DESCRIPTION
Fixes #12 
- [x] Implement Babel plugin for querying API
- [x] Tests for Babel Plugin
- [x] Helper runtime for Babel plugin
- [x] More advanced Babel plugin behaviour which allows imported symbols.
