### PR TITLE
Implement metadata injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "invariant": "^2.1.0",
     "json-loader": "^0.5.3",
     "minimatch": "^2.0.10",
+    "react-helmet": "^1.1.5",
     "react-transform-hmr": "^1.0.0",
     "rimraf": "^2.4.3",
     "sitegen-loader-markdown": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-helmet": "^1.1.5",
     "react-transform-hmr": "^1.0.0",
     "rimraf": "^2.4.3",
-    "sitegen-loader-markdown": "^0.1.6",
+    "sitegen-loader-markdown": "^0.2.0",
     "style-loader": "^0.12.4",
     "url-loader": "^0.5.6",
     "webpack": "^1.12.1",

--- a/src/Meta.js
+++ b/src/Meta.js
@@ -1,0 +1,1 @@
+export {default as default} from 'react-helmet';

--- a/src/RenderStaticPlugin.js
+++ b/src/RenderStaticPlugin.js
@@ -67,8 +67,12 @@ export default class RenderStaticPlugin {
           reject(error);
         } else {
           let innerMarkup = renderToString(<RoutingContext {...props} />);
+          let {title, meta, link} = routes.getRenderedMeta();
           let markup = renderToStaticMarkup(
             <Site
+              title={title}
+              meta={meta}
+              link={link}
               jsBundlePath={'/' + JS_BUNDLE_NAME}
               cssBundlePath={'/' + CSS_BUNDLE_NAME}
               linkRegistry={linkRegistry}>

--- a/src/Site.js
+++ b/src/Site.js
@@ -5,24 +5,42 @@ export default class Site extends React.Component {
 
   static propTypes = {
     children: PropTypes.node,
-    head: PropTypes.node,
+
     jsBundlePath: PropTypes.string,
+
     cssBundlePath: PropTypes.string,
+
+    title: PropTypes.string,
+
+    meta: PropTypes.node,
+
+    link: PropTypes.node,
+
     linkRegistry: PropTypes.object,
   };
 
   render() {
-    let {children, head, jsBundlePath, cssBundlePath, linkRegistry} = this.props;
+    let {
+      children,
+      title,
+      meta,
+      link,
+      jsBundlePath,
+      cssBundlePath,
+      linkRegistry,
+    } = this.props;
     return (
       <html>
         <head>
           <meta charSet="utf8" />
-          <CSSBundle path={cssBundlePath} />
-          {head}
+          {title && <title>{title}</title>}
+          {meta}
+          {link}
         </head>
         <body>
           <RenderRoot markup={children} />
           <LinkRegistry linkRegistry={linkRegistry} />
+          <CSSBundle path={cssBundlePath} />
           <JSBundle path={jsBundlePath} />
           <StartSite path={jsBundlePath} />
         </body>

--- a/src/createSite.js
+++ b/src/createSite.js
@@ -6,6 +6,7 @@ import RenderRoot               from './RenderRoot';
 import createPage               from './createPage';
 import * as RouteUtils          from './RouteUtils';
 import * as LinkRegistry        from './LinkRegistry';
+import Meta                     from './Meta';
 
 function initializeLinkRegistry(routes) {
   if (LinkRegistry.isInitialized()) {
@@ -16,7 +17,13 @@ function initializeLinkRegistry(routes) {
 }
 
 export default function createSite(spec, key) {
-  let routes = {...createPage(spec, key)};
+  let routes = {
+    ...createPage(spec, key),
+
+    getRenderedMeta() {
+      return Meta.rewind();
+    }
+  };
 
   routes.renderIntoDocument = function(element = RenderRoot.getDOMNode()) {
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,3 +2,4 @@ export Site               from './Site';
 export createPage         from './createPage';
 export createSite         from './createSite';
 export * as LinkRegistry  from './LinkRegistry';
+export Meta               from './Meta';


### PR DESCRIPTION
Fixes #7 
- [x] Implement metadata rendering on server
- [x] Implement metadata injection API (using React Helmet)
- [x] Update `sitegen-markdown-loader` to inject metadata
